### PR TITLE
Add support for labels with spaces

### DIFF
--- a/OctoHook.AutoLabel/AutoLabel.cs
+++ b/OctoHook.AutoLabel/AutoLabel.cs
@@ -16,7 +16,7 @@
 	{
 		static readonly ITracer tracer = Tracer.Get<AutoLabel>();
 		// \u2713 == ✓
-		static readonly Regex expression = new Regex(@"\s(?<fullLabel>[\u2713|+|-](?<simpleLabel>[^\s]+))$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+		static readonly Regex expression = new Regex(@"\s(?<fullLabel>[\u2713|+|-](?<simpleLabel>([^\s]+|[""']\\?.*?)))$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
 		IGitHubClient github;
 		List<string> labels;
@@ -40,8 +40,10 @@
 					.ToList();
 			}
 
+		    var bareLabel = match.Groups["simpleLabel"].Value.Replace("\"", string.Empty);
+
 			// Match label in case-insensitive manner, without the prefix first
-			var label = labels.FirstOrDefault(l => string.Equals(l, match.Groups["simpleLabel"].Value, StringComparison.OrdinalIgnoreCase));
+			var label = labels.FirstOrDefault(l => string.Equals(l, bareLabel, StringComparison.OrdinalIgnoreCase));
 			if (label == null)
 				// Labels themselves could use the "+" sign, so we match next by the full string.
 				label = labels.FirstOrDefault(l => string.Equals(l, match.Groups["fullLabel"].Value, StringComparison.OrdinalIgnoreCase));
@@ -54,7 +56,7 @@
 			else
 			{
 				// Just apply the bare label as-is otherwise.
-				label = match.Groups["simpleLabel"].Value;
+			    label = bareLabel;
 				update.AddLabel(label);
 				tracer.Verbose("Applied ad-hoc label '{0}'", label);
 			}


### PR DESCRIPTION
When specifying a label with spaces (e.g. "technical debt"), the AutoLabel processing step did not recognize the label request. This change enables labels with spaces to be applied by permitting double quotes.

Authorized by @kzu in #7

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kzu/octohook/9)

<!-- Reviewable:end -->
